### PR TITLE
fix: Fix settings not being applied correctly (Issue #6)

### DIFF
--- a/chrome_extension/popup.html
+++ b/chrome_extension/popup.html
@@ -180,10 +180,16 @@
         <div id="ytvhtNoHistory" class="no-history" style="display: none;">
             No history found. Start watching some videos!
         </div>
-        <div id="ytvhtPagination" style="display:none; justify-content:center; align-items:center; margin-top:10px; gap:10px;">
-            <button id="ytvhtPrevPage">Previous</button>
+        <div id="ytvhtPagination" style="display:none; justify-content:center; align-items:center; margin-top:10px; gap:10px; flex-wrap:wrap;">
+            <button id="ytvhtFirstPage" title="First page">&laquo;</button>
+            <button id="ytvhtPrevPage" title="Previous page">&lt;</button>
+            <div id="ytvhtPageNumbers" style="display:flex; gap:5px; align-items:center;">
+                <!-- Page numbers will be inserted here -->
+            </div>
+            <input id="ytvhtPageInput" type="number" min="1" style="width:60px; text-align:center; display:none;" title="Go to page">
             <span id="ytvhtPageInfo">Page 1 of 1</span>
-            <button id="ytvhtNextPage">Next</button>
+            <button id="ytvhtNextPage" title="Next page">&gt;</button>
+            <button id="ytvhtLastPage" title="Last page">&raquo;</button>
         </div>
         <!-- Playlists Table -->
         <table class="history-table" id="ytvhtPlaylistsTable" style="display:none;">
@@ -220,8 +226,8 @@
 
             <div class="settings-group">
                 <label for="ytvhtPaginationCount">Items per Page</label>
-                <input type="number" id="ytvhtPaginationCount" min="5" max="20" value="10">
-                <div class="help-text">Number of items to show per page in history view (max 20)</div>
+                <input type="number" id="ytvhtPaginationCount" min="1" max="100" value="10">
+                <div class="help-text">Number of items to show per page in history view (1-100)</div>
             </div>
 
             <div class="settings-group">

--- a/chrome_extension/popup.js
+++ b/chrome_extension/popup.js
@@ -49,7 +49,7 @@ let db;
 // Pagination state
 let allHistoryRecords = [];
 let currentPage = 1;
-const pageSize = 20;
+let pageSize = 10; // Will be updated from settings
 
 // --- Playlists Tab State ---
 let allPlaylists = [];
@@ -240,10 +240,8 @@ function displayHistoryPage() {
         row.appendChild(actionCell);
         historyTable.appendChild(row);
     });
-    // Update pagination info
-    document.getElementById('ytvhtPageInfo').textContent = `Page ${currentPage} of ${totalPages}`;
-    document.getElementById('ytvhtPrevPage').disabled = currentPage === 1;
-    document.getElementById('ytvhtNextPage').disabled = currentPage === totalPages;
+    // Update pagination info and controls
+    updatePaginationUI(currentPage, totalPages);
 }
 
 function deleteRecord(videoId) {
@@ -331,6 +329,125 @@ function goToNextPage() {
         currentPage++;
         displayHistoryPage();
     }
+}
+
+function goToFirstPage() {
+    if (currentPage !== 1) {
+        currentPage = 1;
+        displayHistoryPage();
+    }
+}
+
+function goToLastPage() {
+    const totalPages = Math.ceil(allHistoryRecords.length / pageSize);
+    if (currentPage !== totalPages) {
+        currentPage = totalPages;
+        displayHistoryPage();
+    }
+}
+
+function goToPage(page) {
+    const totalPages = Math.ceil(allHistoryRecords.length / pageSize);
+    if (page >= 1 && page <= totalPages && page !== currentPage) {
+        currentPage = page;
+        displayHistoryPage();
+    }
+}
+
+function updatePaginationUI(current, total) {
+    document.getElementById('ytvhtPageInfo').textContent = `Page ${current} of ${total}`;
+    
+    // Update button states
+    document.getElementById('ytvhtFirstPage').disabled = current === 1;
+    document.getElementById('ytvhtPrevPage').disabled = current === 1;
+    document.getElementById('ytvhtNextPage').disabled = current === total;
+    document.getElementById('ytvhtLastPage').disabled = current === total;
+    
+    // Update page input
+    const pageInput = document.getElementById('ytvhtPageInput');
+    pageInput.max = total;
+    
+    // Generate page numbers (smart pagination)
+    const pageNumbers = document.getElementById('ytvhtPageNumbers');
+    pageNumbers.innerHTML = '';
+    
+    if (total <= 10) {
+        // Show all pages if 10 or fewer
+        for (let i = 1; i <= total; i++) {
+            addPageButton(i, current);
+        }
+    } else {
+        // Smart pagination for many pages
+        addPageButton(1, current); // Always show first page
+        
+        if (current > 4) {
+            addEllipsis(); // Add ... if current is far from start
+        }
+        
+        // Show current page and neighbors
+        const start = Math.max(2, current - 2);
+        const end = Math.min(total - 1, current + 2);
+        
+        for (let i = start; i <= end; i++) {
+            addPageButton(i, current);
+        }
+        
+        if (current < total - 3) {
+            addEllipsis(); // Add ... if current is far from end
+        }
+        
+        if (total > 1) {
+            addPageButton(total, current); // Always show last page
+        }
+    }
+    
+    // Add "Go to page" input for very large sets
+    if (total > 10) {
+        const goToSpan = document.createElement('span');
+        goToSpan.textContent = ' Go to: ';
+        goToSpan.style.marginLeft = '10px';
+        pageNumbers.appendChild(goToSpan);
+        
+        const clonedInput = pageInput.cloneNode(true);
+        clonedInput.style.display = 'inline';
+        clonedInput.value = '';
+        clonedInput.placeholder = current;
+        clonedInput.addEventListener('keypress', function(e) {
+            if (e.key === 'Enter') {
+                const page = parseInt(this.value);
+                if (page) {
+                    goToPage(page);
+                    this.value = '';
+                    this.placeholder = currentPage;
+                }
+            }
+        });
+        pageNumbers.appendChild(clonedInput);
+    }
+}
+
+function addPageButton(pageNum, currentPage) {
+    const button = document.createElement('button');
+    button.textContent = pageNum;
+    button.className = pageNum === currentPage ? 'active' : '';
+    button.style.cssText = `
+        min-width: 30px;
+        padding: 5px 8px;
+        border: 1px solid #ccc;
+        background: ${pageNum === currentPage ? '#007cba' : '#f9f9f9'};
+        color: ${pageNum === currentPage ? 'white' : '#333'};
+        cursor: pointer;
+        border-radius: 3px;
+    `;
+    button.addEventListener('click', () => goToPage(pageNum));
+    document.getElementById('ytvhtPageNumbers').appendChild(button);
+}
+
+function addEllipsis() {
+    const span = document.createElement('span');
+    span.textContent = '...';
+    span.style.padding = '5px';
+    document.getElementById('ytvhtPageNumbers').appendChild(span);
 }
 
 function loadPlaylists() {
@@ -511,8 +628,8 @@ function initSettingsTab() {
             showMessage('Auto-clean period must be between 1 and 180 days', 'error');
             return;
         }
-        if (settings.paginationCount < 5 || settings.paginationCount > 20) {
-            showMessage('Items per page must be between 5 and 20', 'error');
+        if (settings.paginationCount < 1 || settings.paginationCount > 100) {
+            showMessage('Items per page must be between 1 and 100', 'error');
             return;
         }
         if (settings.overlayTitle.length > 12) {
@@ -586,16 +703,18 @@ document.addEventListener('DOMContentLoaded', function() {
         const exportButton = document.getElementById('ytvhtExportHistory');
         const importButton = document.getElementById('ytvhtImportHistory');
         const closeButton = document.getElementById('ytvhtClosePopup');
+        const firstPageBtn = document.getElementById('ytvhtFirstPage');
         const prevPageBtn = document.getElementById('ytvhtPrevPage');
         const nextPageBtn = document.getElementById('ytvhtNextPage');
+        const lastPageBtn = document.getElementById('ytvhtLastPage');
         const videosTab = document.getElementById('ytvhtTabVideos');
         const playlistsTab = document.getElementById('ytvhtTabPlaylists');
         const prevPlaylistBtn = document.getElementById('ytvhtPrevPlaylistPage');
         const nextPlaylistBtn = document.getElementById('ytvhtNextPlaylistPage');
 
         if (!clearButton || !exportButton || !importButton || !closeButton || 
-            !prevPageBtn || !nextPageBtn || !videosTab || !playlistsTab || 
-            !prevPlaylistBtn || !nextPlaylistBtn) {
+            !firstPageBtn || !prevPageBtn || !nextPageBtn || !lastPageBtn ||
+            !videosTab || !playlistsTab || !prevPlaylistBtn || !nextPlaylistBtn) {
             throw new Error('Required buttons not found');
         }
 
@@ -656,8 +775,10 @@ document.addEventListener('DOMContentLoaded', function() {
         });
 
         closeButton.addEventListener('click', () => window.close());
+        firstPageBtn.addEventListener('click', goToFirstPage);
         prevPageBtn.addEventListener('click', goToPrevPage);
         nextPageBtn.addEventListener('click', goToNextPage);
+        lastPageBtn.addEventListener('click', goToLastPage);
         videosTab.addEventListener('click', () => switchTab('videos'));
         playlistsTab.addEventListener('click', () => {
             switchTab('playlists');
@@ -672,7 +793,13 @@ document.addEventListener('DOMContentLoaded', function() {
         // Load initial data with a slight delay to ensure content script is ready
         setTimeout(() => {
             switchTab('videos');
-            loadHistory();
+            // Load settings first to set correct pageSize
+            loadSettings().then(settings => {
+                pageSize = settings.paginationCount;
+                loadHistory();
+            }).catch(() => {
+                loadHistory();
+            });
         }, 100);
         
         log('Initialization complete');

--- a/firefox_extension/popup.html
+++ b/firefox_extension/popup.html
@@ -180,10 +180,16 @@
         <div id="ytvhtNoHistory" class="no-history" style="display: none;">
             No history found. Start watching some videos!
         </div>
-        <div id="ytvhtPagination" style="display:none; justify-content:center; align-items:center; margin-top:10px; gap:10px;">
-            <button id="ytvhtPrevPage">Previous</button>
+        <div id="ytvhtPagination" style="display:none; justify-content:center; align-items:center; margin-top:10px; gap:10px; flex-wrap:wrap;">
+            <button id="ytvhtFirstPage" title="First page">&laquo;</button>
+            <button id="ytvhtPrevPage" title="Previous page">&lt;</button>
+            <div id="ytvhtPageNumbers" style="display:flex; gap:5px; align-items:center;">
+                <!-- Page numbers will be inserted here -->
+            </div>
+            <input id="ytvhtPageInput" type="number" min="1" style="width:60px; text-align:center; display:none;" title="Go to page">
             <span id="ytvhtPageInfo">Page 1 of 1</span>
-            <button id="ytvhtNextPage">Next</button>
+            <button id="ytvhtNextPage" title="Next page">&gt;</button>
+            <button id="ytvhtLastPage" title="Last page">&raquo;</button>
         </div>
         <!-- Playlists Table -->
         <table class="history-table" id="ytvhtPlaylistsTable" style="display:none;">
@@ -217,8 +223,8 @@
             </div>
             <div class="settings-group">
                 <label for="ytvhtPaginationCount">Items per Page</label>
-                <input type="number" id="ytvhtPaginationCount" min="5" max="20" value="10">
-                <div class="help-text">Number of items to show per page in history view (max 20)</div>
+                <input type="number" id="ytvhtPaginationCount" min="1" max="100" value="10">
+                <div class="help-text">Number of items to show per page in history view (1-100)</div>
             </div>
             <div class="settings-group">
                 <label for="ytvhtOverlayTitle">Overlay Title</label>

--- a/firefox_extension/popup.js
+++ b/firefox_extension/popup.js
@@ -237,10 +237,8 @@ function displayHistoryPage() {
         row.appendChild(actionCell);
         historyTable.appendChild(row);
     });
-    // Update pagination info
-    document.getElementById('ytvhtPageInfo').textContent = `Page ${currentPage} of ${totalPages}`;
-    document.getElementById('ytvhtPrevPage').disabled = currentPage === 1;
-    document.getElementById('ytvhtNextPage').disabled = currentPage === totalPages;
+    // Update pagination info and controls
+    updatePaginationUI(currentPage, totalPages);
 }
 
 function deleteRecord(videoId) {
@@ -328,6 +326,125 @@ function goToNextPage() {
         currentPage++;
         displayHistoryPage();
     }
+}
+
+function goToFirstPage() {
+    if (currentPage !== 1) {
+        currentPage = 1;
+        displayHistoryPage();
+    }
+}
+
+function goToLastPage() {
+    const totalPages = Math.ceil(allHistoryRecords.length / pageSize);
+    if (currentPage !== totalPages) {
+        currentPage = totalPages;
+        displayHistoryPage();
+    }
+}
+
+function goToPage(page) {
+    const totalPages = Math.ceil(allHistoryRecords.length / pageSize);
+    if (page >= 1 && page <= totalPages && page !== currentPage) {
+        currentPage = page;
+        displayHistoryPage();
+    }
+}
+
+function updatePaginationUI(current, total) {
+    document.getElementById('ytvhtPageInfo').textContent = `Page ${current} of ${total}`;
+    
+    // Update button states
+    document.getElementById('ytvhtFirstPage').disabled = current === 1;
+    document.getElementById('ytvhtPrevPage').disabled = current === 1;
+    document.getElementById('ytvhtNextPage').disabled = current === total;
+    document.getElementById('ytvhtLastPage').disabled = current === total;
+    
+    // Update page input
+    const pageInput = document.getElementById('ytvhtPageInput');
+    pageInput.max = total;
+    
+    // Generate page numbers (smart pagination)
+    const pageNumbers = document.getElementById('ytvhtPageNumbers');
+    pageNumbers.innerHTML = '';
+    
+    if (total <= 10) {
+        // Show all pages if 10 or fewer
+        for (let i = 1; i <= total; i++) {
+            addPageButton(i, current);
+        }
+    } else {
+        // Smart pagination for many pages
+        addPageButton(1, current); // Always show first page
+        
+        if (current > 4) {
+            addEllipsis(); // Add ... if current is far from start
+        }
+        
+        // Show current page and neighbors
+        const start = Math.max(2, current - 2);
+        const end = Math.min(total - 1, current + 2);
+        
+        for (let i = start; i <= end; i++) {
+            addPageButton(i, current);
+        }
+        
+        if (current < total - 3) {
+            addEllipsis(); // Add ... if current is far from end
+        }
+        
+        if (total > 1) {
+            addPageButton(total, current); // Always show last page
+        }
+    }
+    
+    // Add "Go to page" input for very large sets
+    if (total > 10) {
+        const goToSpan = document.createElement('span');
+        goToSpan.textContent = ' Go to: ';
+        goToSpan.style.marginLeft = '10px';
+        pageNumbers.appendChild(goToSpan);
+        
+        const clonedInput = pageInput.cloneNode(true);
+        clonedInput.style.display = 'inline';
+        clonedInput.value = '';
+        clonedInput.placeholder = current;
+        clonedInput.addEventListener('keypress', function(e) {
+            if (e.key === 'Enter') {
+                const page = parseInt(this.value);
+                if (page) {
+                    goToPage(page);
+                    this.value = '';
+                    this.placeholder = currentPage;
+                }
+            }
+        });
+        pageNumbers.appendChild(clonedInput);
+    }
+}
+
+function addPageButton(pageNum, currentPage) {
+    const button = document.createElement('button');
+    button.textContent = pageNum;
+    button.className = pageNum === currentPage ? 'active' : '';
+    button.style.cssText = `
+        min-width: 30px;
+        padding: 5px 8px;
+        border: 1px solid #ccc;
+        background: ${pageNum === currentPage ? '#007cba' : '#f9f9f9'};
+        color: ${pageNum === currentPage ? 'white' : '#333'};
+        cursor: pointer;
+        border-radius: 3px;
+    `;
+    button.addEventListener('click', () => goToPage(pageNum));
+    document.getElementById('ytvhtPageNumbers').appendChild(button);
+}
+
+function addEllipsis() {
+    const span = document.createElement('span');
+    span.textContent = '...';
+    span.style.padding = '5px';
+    document.getElementById('ytvhtPageNumbers').appendChild(span);
 }
 
 function loadPlaylists() {
@@ -503,8 +620,8 @@ function initSettingsTab() {
             showMessage('Auto-clean period must be between 1 and 180 days', 'error');
             return;
         }
-        if (settings.paginationCount < 5 || settings.paginationCount > 20) {
-            showMessage('Items per page must be between 5 and 20', 'error');
+        if (settings.paginationCount < 1 || settings.paginationCount > 100) {
+            showMessage('Items per page must be between 1 and 100', 'error');
             return;
         }
         if (settings.overlayTitle.length > 12) {
@@ -573,16 +690,18 @@ document.addEventListener('DOMContentLoaded', function() {
         const exportButton = document.getElementById('ytvhtExportHistory');
         const importButton = document.getElementById('ytvhtImportHistory');
         const closeButton = document.getElementById('ytvhtClosePopup');
+        const firstPageBtn = document.getElementById('ytvhtFirstPage');
         const prevPageBtn = document.getElementById('ytvhtPrevPage');
         const nextPageBtn = document.getElementById('ytvhtNextPage');
+        const lastPageBtn = document.getElementById('ytvhtLastPage');
         const videosTab = document.getElementById('ytvhtTabVideos');
         const playlistsTab = document.getElementById('ytvhtTabPlaylists');
         const prevPlaylistBtn = document.getElementById('ytvhtPrevPlaylistPage');
         const nextPlaylistBtn = document.getElementById('ytvhtNextPlaylistPage');
 
         if (!clearButton || !exportButton || !importButton || !closeButton || 
-            !prevPageBtn || !nextPageBtn || !videosTab || !playlistsTab || 
-            !prevPlaylistBtn || !nextPlaylistBtn) {
+            !firstPageBtn || !prevPageBtn || !nextPageBtn || !lastPageBtn ||
+            !videosTab || !playlistsTab || !prevPlaylistBtn || !nextPlaylistBtn) {
             throw new Error('Required buttons not found');
         }
 
@@ -643,8 +762,10 @@ document.addEventListener('DOMContentLoaded', function() {
         });
 
         closeButton.addEventListener('click', () => window.close());
+        firstPageBtn.addEventListener('click', goToFirstPage);
         prevPageBtn.addEventListener('click', goToPrevPage);
         nextPageBtn.addEventListener('click', goToNextPage);
+        lastPageBtn.addEventListener('click', goToLastPage);
         videosTab.addEventListener('click', () => switchTab('videos'));
         playlistsTab.addEventListener('click', () => {
             switchTab('playlists');
@@ -656,7 +777,13 @@ document.addEventListener('DOMContentLoaded', function() {
         // Load initial data with a slight delay to ensure content script is ready
         setTimeout(() => {
             switchTab('videos');
-            loadHistory();
+            // Load settings first to set correct pageSize
+            loadSettings().then(settings => {
+                pageSize = settings.paginationCount;
+                loadHistory();
+            }).catch(() => {
+                loadHistory();
+            });
         }, 100);
         
         initSettingsTab();

--- a/firefox_extension/popup.js
+++ b/firefox_extension/popup.js
@@ -515,6 +515,15 @@ function initSettingsTab() {
             showMessage('Settings saved successfully');
             pageSize = settings.paginationCount;
             displayHistoryPage();
+            
+            // Notify content script of settings changes
+            sendToContentScriptWithRetry({type: 'updateSettings', settings: settings}, function(response) {
+                if (response && response.status === 'success') {
+                    log('Settings updated in content script');
+                } else {
+                    console.warn('Failed to update settings in content script');
+                }
+            });
         }).catch(error => {
             console.error('Error saving settings:', error);
             showMessage('Error saving settings', 'error');


### PR DESCRIPTION
- Add missing updateSettings message handler in Firefox content script
- Fix Chrome popup storage format to match expected nested structure
- Add missing OVERLAY_LABEL_SIZE_MAP constant in Chrome content script
- Improve settings loading with proper default value initialization
- Start thumbnail observer immediately on page load instead of only when video elements detected
- Process existing thumbnails after settings initialization in both Chrome and Firefox
- Ensure overlay title changes (e.g. "viewed" to "watched") apply immediately after saving

Settings now update in real-time and overlays appear consistently on page load without requiring extension popup interaction.