### PR TITLE
33 240 settings not sticking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ![Tests](https://github.com/EdinUser/YouTubeLocalHistory/actions/workflows/ci.yml/badge.svg)
 ![Release](https://img.shields.io/github/v/release/EdinUser/YouTubeLocalHistory)
-![License](https://img.shields.io/github/license/EdinUser/YouTubeLocalHistory)
+![Privacy First](https://img.shields.io/badge/Privacy-First-blueviolet?logo=privateinternetaccess)
+[![Browser Support](https://img.shields.io/badge/Browser_Compatibility-Chrome_&_Firefox-brightgreen?logo=googlechrome&logoColor=white)](https://github.com/EdinUser/YouTubeLocalHistory#installation)
+![Local Storage](https://img.shields.io/badge/Data%20Storage-Local_Only-orange?logo=databricks)
 
 A browser extension that tracks your YouTube video watch history locally using secure browser storage. This extension automatically saves your progress in videos and shows visual indicators for videos you've already watched.
 

--- a/src/content.js
+++ b/src/content.js
@@ -389,8 +389,7 @@
     // Load settings from browser.storage.local
     async function loadSettings() {
         try {
-            const storedSettings = await ytStorage.getSettings();
-            let settings = storedSettings?.settings || {};
+            const settings = await ytStorage.getSettings() || {};
             let updated = false;
 
             // Ensure all default settings are present
@@ -403,7 +402,7 @@
 
             // Save updated settings if needed
             if (updated) {
-                await ytStorage.setSettings({id: 'userSettings', settings});
+                await ytStorage.setSettings(settings);
             }
 
             currentSettings = settings;

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Local YouTube Video History Tracker",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "description": "Store YouTube video timestamps using secure browser storage for larger storage capacity without expiry.",
     "author": "Edin User",
     "homepage_url": "https://github.com/EdinUser/YouTubeLocalHistory",

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Local YouTube Video History Tracker",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Store YouTube video timestamps using secure browser storage for larger storage capacity without expiry.",
   "author": "Edin User",
   "homepage_url": "https://github.com/EdinUser/YouTubeLocalHistory",

--- a/src/popup.js
+++ b/src/popup.js
@@ -778,8 +778,7 @@ async function deletePlaylist(playlistId) {
 // Load settings from storage
 async function loadSettings() {
     try {
-        const storedSettings = await ytStorage.getSettings() || {};
-        let settings = {...storedSettings};
+        const settings = await ytStorage.getSettings() || {};
         let updated = false;
 
         // Ensure all default settings exist
@@ -805,6 +804,10 @@ async function loadSettings() {
 // Save settings to storage
 async function saveSettings(settings) {
     try {
+        // Remove parasite sub-object if present
+        if ('settings' in settings) {
+            delete settings.settings;
+        }
         await ytStorage.setSettings(settings);
         return true;
     } catch (error) {


### PR DESCRIPTION
This pull request introduces updates to improve functionality, enhance metadata, and refine the user experience for the "Local YouTube Video History Tracker" browser extension. The most significant changes include adjustments to settings management, metadata updates in manifest files, and enhancements to the `README.md` file.

### Settings Management Improvements:
* [`src/content.js`](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fL392-R392): Simplified the logic for loading and saving settings by removing unnecessary nested objects in `ytStorage.getSettings` and `ytStorage.setSettings`. [[1]](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fL392-R392) [[2]](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fL406-R405)
* [`src/popup.js`](diffhunk://#diff-3c22697f71643bb8287c56e99e71595d2253122520883f9319e9b27140da5019R807-R810): Added logic to clean up redundant sub-objects in settings before saving, ensuring a more streamlined data structure.

### Metadata Updates:
* `src/manifest.chrome.json` and `src/manifest.firefox.json`: Updated the extension version from `2.4.0` to `2.4.1` to reflect the new changes. [[1]](diffhunk://#diff-c7c383bb167fe9220fe84b04e9c98420a22ba12ba9c8af68cd3ec492382eebfcL4-R4) [[2]](diffhunk://#diff-835b50967034394b01985a03ed1fdac713d8d088b86aa88974cf0e4037baf28aL4-R4)

### README Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R7): Replaced the "License" badge with a "Privacy First" badge and added badges for browser compatibility and local storage usage to better communicate the extension's features and principles.