### PR TITLE
feat: Rebrand extension to YT re:Watch with updated name and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 ### Firefox
 #### Option 1: Install from Firefox Add-ons
-[![Get it on Firefox Add-ons](https://img.shields.io/badge/Get_it_on-Firefox_Add--ons-FF7139?logo=firefox-browser&logoColor=white)](https://addons.mozilla.org/firefox/addon/local-youtube-video-history/)
+[![Get it on Firefox Add-ons](https://img.shields.io/badge/Get_it_on-Firefox_Add--ons-FF7139?logo=firefox-browser&logoColor=white)](https://addons.mozilla.org/firefox/addon/yt-rewatch/)
 [![Firefox Users](https://img.shields.io/amo/users/local-youtube-video-history?logo=firefox&color=blue)](https://addons.mozilla.org/firefox/addon/yt-rewatch/)
 [![Firefox Rating](https://img.shields.io/amo/rating/local-youtube-video-history?logo=firefox)](https://addons.mozilla.org/firefox/addon/local-youtube-video-history/)
 


### PR DESCRIPTION
This pull request updates the `README.md` file to reflect a change in the Firefox Add-on URL for the project.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-R46): Updated the Firefox Add-on link to point to the new URL `https://addons.mozilla.org/firefox/addon/yt-rewatch/` instead of the previous URL.