### PR TITLE
feat: Add support section with Patreon link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,3 +381,9 @@ This extension supports multiple languages:
 - Bulgarian (bg)
 
 **Note:** All non-English translations are currently machine-generated. If you are a native speaker and notice any issues, please consider contributing improvements! See `src/_locales/README.md` for translation guidelines.
+
+## ❤️ Support the Project
+
+If you find YT re:Watch useful, consider supporting development on [Patreon](https://patreon.com/EdinUser)!
+
+[![Support on Patreon](https://img.shields.io/badge/Support%20on-Patreon-orange?logo=patreon&logoColor=white)](https://patreon.com/EdinUser)

--- a/docs/DETAILED_GUIDE.md
+++ b/docs/DETAILED_GUIDE.md
@@ -1,3 +1,9 @@
+# ❤️ Support the Project
+
+If you find YT re:Watch helpful, you can support ongoing development on [Patreon](https://patreon.com/EdinUser)!
+
+[![Support on Patreon](https://img.shields.io/badge/Support%20on-Patreon-orange?logo=patreon&logoColor=white)](https://patreon.com/EdinUser)
+
 # 📖 Complete User Guide for YT re:Watch
 
 *A step-by-step guide to master your YouTube viewing experience*

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -15,6 +15,12 @@
   *Keep track of your YouTube journey - Your data stays private on your device*
 </div>
 
+# ❤️ Support the Project
+
+If you find YT re:Watch helpful, you can support ongoing development on [Patreon](https://patreon.com/EdinUser)!
+
+[![Support on Patreon](https://img.shields.io/badge/Support%20on-Patreon-orange?logo=patreon&logoColor=white)](https://patreon.com/EdinUser)
+
 ---
 
 ## 🤔 What is YT re:Watch?

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,11 @@
 # 📚 YT re:Watch Documentation
 
+# ❤️ Support the Project
+
+If you find YT re:Watch helpful, you can support ongoing development on [Patreon](https://patreon.com/EdinUser)!
+
+[![Support on Patreon](https://img.shields.io/badge/Support%20on-Patreon-orange?logo=patreon&logoColor=white)](https://patreon.com/EdinUser)
+
 Welcome! Find the right guide for you:
 
 ## 🎯 **Choose Your Guide**


### PR DESCRIPTION
This pull request introduces a new section across multiple documentation files to encourage users to support the development of the YT re:Watch project via Patreon. The changes add a consistent "Support the Project" message and a Patreon badge to enhance visibility and engagement.

Addition of "Support the Project" section:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R384-R389): Added a "Support the Project" section with a message and Patreon badge to encourage contributions.
* [`docs/DETAILED_GUIDE.md`](diffhunk://#diff-a754b904b7d56b485700cb2b9c7c0900137ac18630fd1159161b2413997a1862R1-R6): Included the "Support the Project" section at the beginning of the detailed guide documentation.
* [`docs/INDEX.md`](diffhunk://#diff-d08e66411886fba7c1228b4471c4189e78f4b75dd739b0d5e2a1c2c3cc525e14R18-R23): Added the "Support the Project" section near the top of the index documentation.
* [`docs/README.md`](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R3-R8): Incorporated the "Support the Project" section at the start of the documentation overview.