### PR TITLE
Fix/overlay issue with right column videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,6 @@ All notable changes to YT re:Watch will be documented in this file.
 
 ## [3.0.1]
 
-### 🐛 Bug Fixes
-- **Video Overlay**: Fixed an issue where the "viewed" overlay was not appearing on related videos in the right-hand column of a video page. This was caused by a YouTube UI update that introduced a new `yt-lockup-view-model` element, which is now correctly handled.
-
----
-
-## [3.0.1]
-
 ### ✨ Major New Features
 
 #### 🔄 Tombstone-Based Deletion System
@@ -23,6 +16,9 @@ All notable changes to YT re:Watch will be documented in this file.
 - **Fixed deleted videos reappearing** after sync operations
 - **Resolved immediate video restoration** when delete button was clicked
 - **Enhanced popup filtering** prevents deleted videos from appearing in the UI
+
+### 🐛 Bug Fixes
+- **Video Overlay**: Fixed an issue where the "viewed" overlay was not appearing on related videos in the right-hand column of a video page. This was caused by a YouTube UI update that introduced a new `yt-lockup-view-model` element, which is now correctly handled.
 
 ### 🛠️ Other Improvements
 - Automatic tombstone cleanup and storage optimization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to YT re:Watch will be documented in this file.
 
 ## [3.0.1]
 
+### 🐛 Bug Fixes
+- **Video Overlay**: Fixed an issue where the "viewed" overlay was not appearing on related videos in the right-hand column of a video page. This was caused by a YouTube UI update that introduced a new `yt-lockup-view-model` element, which is now correctly handled.
+
+---
+
+## [3.0.1]
+
 ### ✨ Major New Features
 
 #### 🔄 Tombstone-Based Deletion System

--- a/src/content.js
+++ b/src/content.js
@@ -1028,6 +1028,14 @@
             }
         }
 
+        if (thumbnail.tagName === 'YT-LOCKUP-VIEW-MODEL' || thumbnail.closest('yt-lockup-view-model')) {
+            const lockupLink = thumbnail.querySelector('a[href*="watch?v="]');
+            if (lockupLink) {
+                const videoId = lockupLink.href.match(/[?&]v=([^&]+)/)?.[1];
+                return videoId;
+            }
+        }
+
         // Check for regular video links
         let anchor = thumbnail.querySelector('a#thumbnail[href*="watch?v="], a#video-title[href*="watch?v="]');
         if (anchor) {
@@ -1060,8 +1068,16 @@
         // For playlist items, we need to target the thumbnail container
         let targetElement = thumbnailElement;
         
+        if (thumbnailElement.tagName === 'YT-LOCKUP-VIEW-MODEL' || thumbnailElement.closest('yt-lockup-view-model')) {
+            const thumbnailContainer = thumbnailElement.querySelector('.yt-lockup-view-model-wiz__content-image');
+            if (thumbnailContainer) {
+                targetElement = thumbnailContainer;
+            } else {
+                return;
+            }
+        }
         // If we're in a playlist panel video renderer, find the thumbnail container
-        if (thumbnailElement.tagName === 'YTD-PLAYLIST-PANEL-VIDEO-RENDERER' || thumbnailElement.closest('ytd-playlist-panel-video-renderer')) {
+        else if (thumbnailElement.tagName === 'YTD-PLAYLIST-PANEL-VIDEO-RENDERER' || thumbnailElement.closest('ytd-playlist-panel-video-renderer')) {
             const thumbnailContainer = thumbnailElement.querySelector('#thumbnail-container ytd-thumbnail') || 
                                     thumbnailElement.querySelector('ytd-thumbnail') ||
                                     thumbnailElement.querySelector('#thumbnail-container');
@@ -1142,7 +1158,7 @@
             if (mutation.type === 'attributes') {
                 const target = mutation.target;
                 if (target.tagName === 'IMG' && target.id === 'img') {
-                    const videoElement = target.closest('ytd-playlist-panel-video-renderer, ytd-playlist-video-renderer, ytd-rich-item-renderer, ytd-grid-video-renderer, ytd-video-renderer, ytd-compact-video-renderer, ytd-compact-radio-renderer');
+                    const videoElement = target.closest('ytd-playlist-panel-video-renderer, ytd-playlist-video-renderer, ytd-rich-item-renderer, ytd-grid-video-renderer, ytd-video-renderer, ytd-compact-video-renderer, ytd-compact-radio-renderer, yt-lockup-view-model');
                     if (videoElement) {
                         processVideoElement(videoElement);
                     }
@@ -1161,13 +1177,14 @@
                         node.tagName === 'YTD-GRID-VIDEO-RENDERER' ||
                         node.tagName === 'YTD-VIDEO-RENDERER' ||
                         node.tagName === 'YTD-COMPACT-VIDEO-RENDERER' ||
-                        node.tagName === 'YTD-COMPACT-RADIO-RENDERER'
+                        node.tagName === 'YTD-COMPACT-RADIO-RENDERER' ||
+                        node.tagName === 'YT-LOCKUP-VIEW-MODEL'
                     )) {
                         processVideoElement(node);
                     }
 
                     // Also check for video elements inside the added node
-                    const videoElements = node.querySelectorAll('ytd-playlist-panel-video-renderer, ytd-playlist-video-renderer, ytd-rich-item-renderer, ytd-grid-video-renderer, ytd-video-renderer, ytd-compact-video-renderer, ytd-compact-radio-renderer');
+                    const videoElements = node.querySelectorAll('ytd-playlist-panel-video-renderer, ytd-playlist-video-renderer, ytd-rich-item-renderer, ytd-grid-video-renderer, ytd-video-renderer, ytd-compact-video-renderer, ytd-compact-radio-renderer, yt-lockup-view-model');
                     if (videoElements.length > 0) {
                         videoElements.forEach(element => processVideoElement(element));
                     }
@@ -1191,7 +1208,7 @@
         mainThumbnails.forEach(element => processVideoElement(element));
 
         // Process right column recommendations
-        const rightColumnThumbnails = document.querySelectorAll('ytd-compact-video-renderer, ytd-compact-radio-renderer');
+        const rightColumnThumbnails = document.querySelectorAll('ytd-compact-video-renderer, ytd-compact-radio-renderer, yt-lockup-view-model');
         rightColumnThumbnails.forEach(element => processVideoElement(element));
     }
 


### PR DESCRIPTION
This pull request addresses a bug caused by a YouTube UI update, ensuring compatibility with the new `yt-lockup-view-model` element. The changes primarily focus on fixing the "viewed" overlay issue and updating the logic to handle this new element across various sections of the code.

### Bug Fixes:
* **Video Overlay**: Fixed the "viewed" overlay issue on related videos in the right-hand column by correctly handling the new `yt-lockup-view-model` element introduced in a YouTube update. (`CHANGELOG.md`)

### Code Updates for Compatibility:
* **Thumbnail Processing Logic**: Added support for detecting and processing thumbnails within the `yt-lockup-view-model` element to retrieve video IDs and ensure proper overlay functionality. (`src/content.js`) [[1]](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fR1031-R1038) [[2]](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fR1071-R1080)
* **Mutation Observer Updates**: Updated mutation observer logic to include `yt-lockup-view-model` when identifying video elements for processing. (`src/content.js`) [[1]](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fL1145-R1161) [[2]](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fL1164-R1187)
* **Recommendation Thumbnails**: Extended the processing of right-column recommendations to include thumbnails within the `yt-lockup-view-model` element. (`src/content.js`)