### PR TITLE
fix(sync): reduce sync frequency and disable immediate sync by default

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -61,6 +61,8 @@
     class SimpleStorage {
         constructor() {
             this.migrated = false;
+            // Disable immediate sync on every update by default
+            this.immediateSyncOnUpdate = false;
         }
 
         // Check if migration is needed and perform it
@@ -176,8 +178,10 @@
             await this.ensureMigrated();
             // Always save to local storage first (priority 1)
             await storage.set({[`video_${videoId}`]: data});
-            // Then trigger sync if enabled
-            this.triggerSync(videoId);
+            // Only trigger sync if immediateSyncOnUpdate is true
+            if (this.immediateSyncOnUpdate) {
+                this.triggerSync(videoId);
+            }
         }
 
         // Remove video record
@@ -188,8 +192,10 @@
             // Create a tombstone with deletedAt timestamp
             const tombstoneKey = `deleted_video_${videoId}`;
             await storage.set({[tombstoneKey]: {deletedAt: Date.now()}});
-            // Trigger sync after removal
-            this.triggerSync();
+            // Only trigger sync if immediateSyncOnUpdate is true
+            if (this.immediateSyncOnUpdate) {
+                this.triggerSync();
+            }
         }
 
         // Get all video records

--- a/src/sync-service.js
+++ b/src/sync-service.js
@@ -735,10 +735,10 @@
                 clearInterval(this.syncInterval);
             }
 
-            // Set sync interval to 5 minutes - reasonable fallback since we have immediate sync + storage listeners
+            // Set sync interval to 10 minutes - less frequent to reduce resource usage
             this.syncInterval = setInterval(() => {
                 this.performInitialSync();
-            }, 5 * 60 * 1000); // 5 minutes - balanced between responsiveness and resource usage
+            }, 10 * 60 * 1000); // 10 minutes
 
             // Add Firefox Sync storage change listener for real-time remote updates
             this.setupSyncStorageListener();


### PR DESCRIPTION
- Change sync interval from 5 minutes to 10 minutes to lower resource usage
- Disable immediate sync on updates unless explicitly enabled

This pull request updates the storage synchronization behavior to reduce unnecessary resource usage and provide more control over when syncing occurs. The key changes are grouped below:

**Storage synchronization controls:**

* Added an `immediateSyncOnUpdate` property to the `SimpleStorage` class, defaulting to `false`, to control whether sync is triggered immediately after updates.
* Modified the `saveVideo` and `removeVideo` methods in `SimpleStorage` to only trigger sync if `immediateSyncOnUpdate` is set to `true`. [[1]](diffhunk://#diff-0d294ef99fa537813aa2b3970c56b2d83c1b7077ce17c019a8f3e2b7fcf5216fL179-R185) [[2]](diffhunk://#diff-0d294ef99fa537813aa2b3970c56b2d83c1b7077ce17c019a8f3e2b7fcf5216fL191-R199)

**Sync interval adjustment:**

* Changed the default sync interval in `SyncService` from 5 minutes to 10 minutes to further reduce resource usage.