### PR TITLE
fix(content): improve timestamp validation and optimize timeupdate handling

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -778,9 +778,9 @@
         let currentTime = video.currentTime;
         const duration = video.duration;
 
-        // Do not update record if timestamp is 0 or duration is not available
-        if (!currentTime || currentTime === 0 || !duration || duration === 0) {
-            log(`Invalid timestamp (${currentTime}) or duration (${duration}) for Shorts ID ${videoId}, skipping update.`);
+        // Do not update record if timestamp is 0. Allow duration to be unavailable for Shorts.
+        if (!currentTime || currentTime === 0) {
+            log(`Invalid timestamp (${currentTime}) for Shorts ID ${videoId}, skipping update.`);
             return;
         }
 
@@ -943,7 +943,8 @@
         });
         addTrackedEventListener(video, 'timeupdate', () => {
             const currentTime = Math.floor(video.currentTime);
-            if (currentTime % 15 === 0) debouncedSave();
+            const interval = window.location.pathname.startsWith('/shorts/') ? 5 : 15;
+            if (currentTime > 0 && currentTime % interval === 0) debouncedSave();
         });
         addTrackedEventListener(video, 'seeking', () => {
             if (saveIntervalId) {

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "YT re:Watch",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "YouTube history extension for multiple accounts. Track progress with privacy: visual overlays, account switching, no login required",
     "author": "Edin User",
     "homepage_url": "https://github.com/EdinUser/YouTubeLocalHistory",

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "YT re:Watch",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "YouTube history extension for multiple accounts. Track progress with privacy: visual overlays, account switching, no login required",
     "author": "Edin User",
     "homepage_url": "https://github.com/EdinUser/YouTubeLocalHistory",


### PR DESCRIPTION
- Allow Shorts to proceed with unavailable durations during timestamp validation
- Adjust `timeupdate` interval to 5s for Shorts, 15s for regular videos
- Bump manifest versions to 3.1.1

This pull request introduces improvements to how YouTube Shorts are handled in the extension and updates the manifest version for both Chrome and Firefox. The main changes focus on relaxing timestamp and duration checks for Shorts and optimizing the save interval logic.

**Shorts handling improvements:**

* Relaxed the check for video duration when updating records, allowing Shorts videos without a valid duration to be processed as long as the timestamp is valid.
* Adjusted the save interval for Shorts to every 5 seconds instead of 15, and ensured the save only occurs when the current time is greater than zero.

**Manifest updates:**

* Updated the extension version from `3.1.0` to `3.1.1` in both `src/manifest.chrome.json` and `src/manifest.firefox.json`. [[1]](diffhunk://#diff-c7c383bb167fe9220fe84b04e9c98420a22ba12ba9c8af68cd3ec492382eebfcL4-R4) [[2]](diffhunk://#diff-835b50967034394b01985a03ed1fdac713d8d088b86aa88974cf0e4037baf28aL4-R4)