### PR TITLE
docs(changelog): add 3.1.2 release details and feature updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to YT re:Watch will be documented in this file.
 
+## [3.1.2] - 2025-09-24
+
+### ✨ New Features
+- Persistent, privacy‑preserving watch‑time statistics stored locally (`totalWatchSeconds`, last 7 days `daily`, 24‑slot `hourly`)
+- History list now shows the video channel name beneath the title
+
+### 🧭 Behavior Changes
+- Shorts tracking: save interval aligned to 5s and relaxed duration checks to avoid missed saves
+- Initial stats seeding from existing history for accurate analytics on upgrade
+
+### 📊 Analytics
+- Summary cards and charts now prefer persistent stats for accuracy and performance
+- Activity (last 7 days) and "Watch time by hour" use stored stats with local‑day keys
+
+### 🔄 Sync & Performance (Firefox)
+- Throttled `storage.sync` change listener to prevent self‑triggered loops; ignores self‑writes for 20s and enforces a 5‑minute minimum between listener‑triggered syncs
+- Stats updates are debounced to the background cadence (default ~10 minutes) unless immediate sync is explicitly enabled
+
+### 🗄️ Export/Import
+- Export schema bumped to `dataVersion: "1.1"` and now includes a `stats` object
+
+### 📦 Build & Manifests
+- Version bump to 3.1.2 in Chrome and Firefox manifests
+
+---
+
+## [3.1.1]
+
+### 🐛 Fixes
+- Improved timestamp validation and optimized `timeupdate` handling to reliably record progress
+- Shorts tracking no longer skips saves when duration is unavailable
+
+### 📦 Build & Manifests
+- Version bump to 3.1.1 in Chrome and Firefox manifests
+
+---
+
 ## [3.1.0] - 2025-09-06
 
 ### ✨ New Features

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The extension adds smart visual indicators directly on YouTube:
 - **Adjustable size** - Small, medium, large, or extra-large labels
 - **Works everywhere** - Video listings, search results, recommendations
 
+Additionally, the history list now shows the video’s channel name beneath the title for quicker scanning.
+
 ### 🎛️ **Extension Interface**
 Click the extension icon to access:
 - **Videos Tab** - Your main viewing history with progress tracking
@@ -135,6 +137,8 @@ Click the extension icon to access:
 - **Top Skipped Channels**: See your top 5 channels where you most often skip long videos (with links)
 - **Completion Bar Chart**: Visualize your completion rate for long videos (skipped, partial, completed) with a bar chart and legend
 - **Weekly Activity**: Visualize your YouTube usage patterns
+
+Analytics now prefer locally persisted, privacy-preserving statistics for better accuracy and performance.
 
 ### 🔄 **Cross-Device Sync (Firefox)**
 - **Firefox Sync**: Automatic cross-device synchronization
@@ -192,6 +196,14 @@ Click the extension icon to access:
 
 This extension uses `chrome.storage.local` (Chrome) or `browser.storage.local` (Firefox) for secure data storage instead of IndexedDB. This provides better security as the data cannot be easily accessed through browser developer tools.
 
+### Persistent Statistics
+For faster and more consistent Analytics, the extension maintains a small, local statistics snapshot:
+- `totalWatchSeconds`: cumulative seconds watched
+- `daily`: last 7 days of totals keyed by local date `YYYY-MM-DD`
+- `hourly`: array of 24 totals for each hour of day
+
+These stats are calculated and stored locally only. On first upgrade, they are seeded from your existing history when possible.
+
 ### Migration from IndexedDB
 
 If you're updating from a previous version that used IndexedDB, the extension will automatically migrate your existing data to the new storage system on first run. The migration process:
@@ -207,6 +219,7 @@ The extension stores three types of data:
 - **Video History**: Video IDs, timestamps, progress, titles, and URLs
 - **Playlist History**: Playlist IDs, titles, and URLs
 - **Settings**: User preferences for overlay appearance, cleanup, and theme preferences
+ - **Statistics**: Aggregated watch‑time summaries used for analytics (local only)
 
 ## Usage
 

--- a/docs/DETAILED_GUIDE.md
+++ b/docs/DETAILED_GUIDE.md
@@ -80,11 +80,15 @@ After watching videos, you'll notice:
 
 ![Videos tab interface](./images/ytrw_videos.jpg)
 *The Videos tab shows your complete YouTube watch history, with progress, search, and delete options.*
+  
+Your history list shows the channel name under each video title to help you scan quickly.
 
 ### 🎬 Shorts Tab (YouTube Shorts)
 
 ![Shorts tab interface](./images/ytrw_shorts.jpg)
 *The Shorts tab tracks your YouTube Shorts viewing separately, helping you understand your short-form content habits.*
+  
+Shorts saves are now more reliable: the save cadence is 5 seconds and duration checks are relaxed to avoid missed saves.
 
 ### 📝 Playlists Tab
 
@@ -127,6 +131,8 @@ After watching videos, you'll notice:
 
 ![Analytics activity by day and hour](./images/ytrw_stats3.jpg)
 *Watch activity by day and by hour in the Analytics tab.*
+  
+These charts now prefer locally persisted, privacy‑preserving statistics for better accuracy and responsiveness. Keys are local‑day `YYYY-MM-DD` and 24 hourly buckets.
 
 ### ⚙️ Settings Tab (Customization)
 
@@ -164,6 +170,7 @@ After watching videos, you'll notice:
   - Videos deleted from history won't reappear after sync
   - 30-day protection period ensures deletions persist across all devices
   - Automatic cleanup of deletion markers after 30 days
+ - **Persistent Statistics**: Analytics use a local stats snapshot (total, last 7 daily totals, 24 hourly totals). Seeded from your existing history after upgrade.
 
 **Sync Settings (Firefox Only):**
 - **Enable Sync**: Toggle Firefox Sync integration
@@ -322,6 +329,7 @@ The export file contains:
 - **Video History**: All your watched videos with timestamps
 - **Playlists**: All saved playlists
 - **Settings**: Your customization preferences
+ - **Stats**: Aggregated watch‑time snapshot powering Analytics (from dataVersion 1.1)
 
 ---
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -316,7 +316,13 @@ Check out our [Contributing Guide](./CONTRIBUTING.md) for more details.
 ## 📊 Analytics & Statistics
 
 ### Q: What's new in the Analytics tab?
-**A:** The Analytics tab now features summary cards, longest unfinished videos, top watched/skipped channels, a completion bar chart, and new activity charts. All analytics are calculated locally and never leave your device.
+**A:** The Analytics tab now features summary cards, longest unfinished videos, top watched/skipped channels, a completion bar chart, and new activity charts. All analytics are calculated locally and never leave your device. For accuracy and performance, Analytics prefers a small, locally persisted stats snapshot (total, last 7 daily totals using local days, and 24 hourly totals). It falls back to aggregating from history when needed.
+
+### Q: Why do I see channel names under titles in my history?
+**A:** The history list now displays the channel name under each video title to make scanning your history faster and clearer.
+
+### Q: Did the export format change?
+**A:** Yes. Starting with dataVersion 1.1, exports include a `stats` object containing your aggregated watch‑time snapshot used for Analytics. This is optional data used solely to speed up and stabilize charts. Imports accept files with or without `stats`.
 
 ### Q: How do I interpret the completion bar chart?
 **A:** It shows the number of long videos you skipped, partially watched, or completed. The legend explains each category. 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -116,6 +116,8 @@ The extension adds helpful visual indicators directly on YouTube:
 ### 🎛️ **Extension Interface**
 **Videos Tab** - Your main viewing history:
 ![Videos tab interface](./images/ytrw_videos.jpg)
+  
+Your history list shows the channel name under each video title to help you scan quickly.
 
 **Shorts Tab** - Separate tracking for YouTube Shorts:
 ![Shorts tab interface](./images/ytrw_shorts.jpg)
@@ -129,6 +131,8 @@ The extension adds helpful visual indicators directly on YouTube:
 
 ![Analytics activity by day and hour](./images/ytrw_stats3.jpg)
 *Watch activity by day and by hour in the Analytics tab*
+  
+These charts now prefer locally persisted, privacy‑preserving statistics for better accuracy and responsiveness. Keys are local‑day `YYYY-MM-DD` and 24 hourly buckets.
 
 - **Longest Unfinished Videos**: Resume long videos you haven't finished (shows channel, time left, and link)
 - **Top Watched Channels**: Your top 5 channels by videos watched (with links)

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,12 @@ Welcome! Find the right guide for you:
 - All features explained
 - Customization options
 
+### 🆕 What's New in 3.1.2
+- Persistent, privacy‑preserving watch‑time statistics stored locally for faster Analytics
+- History list shows channel names beneath titles
+- Shorts tracking reliability improvements (save cadence, duration handling)
+- Export now includes `stats` (schema `dataVersion: 1.1`)
+
 ### 🔧 **Developer or Contributor?**
 **[→ Technical Documentation](./TECHNICAL.md)**
 - Architecture details


### PR DESCRIPTION
- Document persistent watch-time stats and analytics improvements
- Add history enhancements (channel names in list) and Shorts tracking fixes
- Outline export schema changes (v1.1) with stats inclusion
- Update sync behavior and performance optimizations for Firefox
- Include manifest version bump to 3.1.2

This pull request documents and explains the new persistent, privacy-preserving watch-time statistics and related analytics improvements introduced in version 3.1.2 of YT re:Watch. The documentation now covers how analytics use locally stored stats for accuracy and performance, changes to Shorts tracking, the addition of channel names in the history list, and updates to the export/import schema. Technical docs now describe the new stats API and data structure, as well as sync throttling and listener behavior.

**Major documentation updates:**

**Persistent Statistics & Analytics Improvements**
- Added explanations and examples for the new persistent stats snapshot (`totalWatchSeconds`, `daily`, `hourly`) stored locally and used for analytics, including fallback behavior and privacy guarantees. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R41) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R141-R142) [[3]](diffhunk://#diff-a754b904b7d56b485700cb2b9c7c0900137ac18630fd1159161b2413997a1862R135-R136) [[4]](diffhunk://#diff-d08e66411886fba7c1228b4471c4189e78f4b75dd739b0d5e2a1c2c3cc525e14R135-R136) [[5]](diffhunk://#diff-90125689b9e777835e5f6ed42276923d217bcf51cd795dec699621248b461aa2R136) [[6]](diffhunk://#diff-0bb42a85d04c8b7c9b659307979fd43e8f6e084283a300bfff959adfcbddfd17L319-R325)
- Described the new statistics API (`getStats`, `setStats`, `updateStats`) and provided a sample stats data structure in the technical documentation. [[1]](diffhunk://#diff-90125689b9e777835e5f6ed42276923d217bcf51cd795dec699621248b461aa2R199-R216) [[2]](diffhunk://#diff-90125689b9e777835e5f6ed42276923d217bcf51cd795dec699621248b461aa2R254-R272)
- Updated analytics/FAQ sections to clarify that summary cards and charts now prefer persistent stats for better accuracy and performance, and that exports from dataVersion 1.1 include a `stats` object. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R41) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R199-R206) [[3]](diffhunk://#diff-a754b904b7d56b485700cb2b9c7c0900137ac18630fd1159161b2413997a1862R332) [[4]](diffhunk://#diff-0bb42a85d04c8b7c9b659307979fd43e8f6e084283a300bfff959adfcbddfd17L319-R325)

**User-Facing Feature Additions**
- Noted that the history list now displays the video channel name beneath each title for easier scanning, with updates in both user and detailed guides. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R41) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106-R107) [[3]](diffhunk://#diff-a754b904b7d56b485700cb2b9c7c0900137ac18630fd1159161b2413997a1862R84-R92) [[4]](diffhunk://#diff-d08e66411886fba7c1228b4471c4189e78f4b75dd739b0d5e2a1c2c3cc525e14R120-R121) [[5]](diffhunk://#diff-0bb42a85d04c8b7c9b659307979fd43e8f6e084283a300bfff959adfcbddfd17L319-R325)
- Documented improvements to Shorts tracking reliability: save cadence is now every 5 seconds and duration checks are relaxed to avoid missed saves. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R41) [[2]](diffhunk://#diff-a754b904b7d56b485700cb2b9c7c0900137ac18630fd1159161b2413997a1862R84-R92) [[3]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R31-R36)

**Sync & Performance (Firefox)**
- Added details on throttling for the `storage.sync` change listener to prevent self-triggered loops, including timeouts and minimum intervals between syncs. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R41) [[2]](diffhunk://#diff-90125689b9e777835e5f6ed42276923d217bcf51cd795dec699621248b461aa2L108-R109)

**Export/Import & Data Schema**
- Explained the export schema bump to `dataVersion: 1.1`, which now includes the `stats` object, and clarified import compatibility. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R41) [[2]](diffhunk://#diff-a754b904b7d56b485700cb2b9c7c0900137ac18630fd1159161b2413997a1862R332) [[3]](diffhunk://#diff-0bb42a85d04c8b7c9b659307979fd43e8f6e084283a300bfff959adfcbddfd17L319-R325)

**Other Documentation Enhancements**
- Updated changelog and "What's New" sections to reflect all of the above changes for version 3.1.2. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R41) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R31-R36)