### PR TITLE
fix: construct feed title icons without innerHTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to YT re:Watch will be documented in this file.
 
+## [5.1.0] - 2026-08-14
+
+### Added
+
+- Added extension-managed local playlists with creation, rename, deletion, ordering, and video actions. These remain separate from YouTube-account playlists.
+- Added a per-channel RSS log in **Channels**, showing the latest 15 successful and failed feed reads with timestamps and HTTP status.
+- Added upload-date and detection-date ordering for Subscriptions, with an explanation of videos hidden by active filters.
+- Unified full-page Feed headers around an icon, title, description, and view-local controls. Added contextual Reload actions and a persisted collapsed sidebar icon rail.
+
+### Changed
+
+- RSS-backed subscriptions now treat temporary YouTube 404, 403, 429, 5xx, timeout, and network failures as retryable. Cached videos remain intact; retries use backoff and jitter; first imports retain priority; and retry-only work is paced conservatively.
+- Popup history is strictly last-watched ordered, including completed videos, and retains the current page during live updates.
+
+### Fixed
+
+- Handled extension-context invalidation without a misleading content-script error.
+- Made release rebuilds preserve the unpacked extension directory instead of requiring extension removal and reinstallation.
+
 ## [5.0.1] - 2026-08-11
 
 ### Fixed

--- a/src/feed-home.js
+++ b/src/feed-home.js
@@ -37,6 +37,28 @@ function applyShortsFilter(list) {
     return shortsOnly ? dedupeShorts(list.filter((v) => isShort(v))) : list.filter((v) => !isShort(v));
 }
 
+function createFeedTitleIcon(kind) {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 24 24');
+    const add = (name, attributes) => {
+        const node = document.createElementNS('http://www.w3.org/2000/svg', name);
+        Object.entries(attributes).forEach(([key, value]) => node.setAttribute(key, value));
+        svg.appendChild(node);
+    };
+    if (kind === 'shorts') {
+        add('path', { d: 'm13.5 2-7 11h5l-1 9 7-12h-5l1-8Z' });
+    } else if (kind === 'subscriptions') {
+        add('rect', { x: '3', y: '6', width: '18', height: '14', rx: '2' });
+        add('path', { d: 'm9 3 3 3 3-3' });
+        add('path', { d: 'm10 10 5 3-5 3v-6Z' });
+    } else {
+        add('path', { d: 'M3 10.8 12 3l9 7.8' });
+        add('path', { d: 'M5.5 9.5V21h13V9.5' });
+        add('path', { d: 'M9.5 21v-7h5v7' });
+    }
+    return svg;
+}
+
 function sortShortsByLastWatched(list) {
     const watchedAt = (video) => Number(
         (video && video.videoId && watchedMap[video.videoId]?.timestamp)
@@ -786,11 +808,9 @@ function render() {
                 : tFeed('feed_title_home_description', 'Personalized locally from your watch history.')));
     if (heading) heading.textContent = title;
     if (titleDescription) titleDescription.textContent = description;
-    if (titleIcon) titleIcon.innerHTML = shortsOnly
-        ? '<svg viewBox="0 0 24 24"><path d="m13.5 2-7 11h5l-1 9 7-12h-5l1-8Z"></path></svg>'
-        : (subscriptionsBrowse
-            ? '<svg viewBox="0 0 24 24"><rect x="3" y="6" width="18" height="14" rx="2"></rect><path d="m9 3 3 3 3-3"></path><path d="m10 10 5 3-5 3v-6Z"></path></svg>'
-            : '<svg viewBox="0 0 24 24"><path d="M3 10.8 12 3l9 7.8"></path><path d="M5.5 9.5V21h13V9.5"></path><path d="M9.5 21v-7h5v7"></path></svg>');
+    if (titleIcon) titleIcon.replaceChildren(createFeedTitleIcon(
+        shortsOnly ? 'shorts' : (subscriptionsBrowse ? 'subscriptions' : 'home')
+    ));
     if (filters) {
         filters.classList.toggle('visible', !!q);
         filters.classList.toggle('open', !!q && searchFiltersOpen);

--- a/tests/unit/feed-shell-layout.test.js
+++ b/tests/unit/feed-shell-layout.test.js
@@ -24,3 +24,11 @@ test('Feed persists the default collapsed icon rail and restores expanded naviga
   expect(source).toContain("localStorage.setItem('ytvhtSidebarCollapsed'");
   expect(source).toContain("item.title = collapsed ? item.textContent.trim() : item.dataset.expandedTitle");
 });
+
+test('Feed title icons are constructed as SVG DOM nodes rather than dynamic HTML', () => {
+  const source = fs.readFileSync(path.join(ROOT, 'src', 'feed-home.js'), 'utf8');
+
+  expect(source).toContain("document.createElementNS('http://www.w3.org/2000/svg', 'svg')");
+  expect(source).toContain('titleIcon.replaceChildren(createFeedTitleIcon(');
+  expect(source).not.toContain('titleIcon.innerHTML');
+});


### PR DESCRIPTION
Summary
- replace the dynamic feed-title SVG innerHTML assignment flagged by Firefox Add-ons
- construct the fixed SVG shapes with namespace-aware DOM nodes
- add a regression assertion for the safe title-icon rendering path

Verification
- focused Jest tests passed
- lint passed
- Firefox build and web-ext lint completed with zero warnings