### PR TITLE
Fix: preserve Subscriptions sort when showing new videos

### DIFF
--- a/src/feed-refresh.js
+++ b/src/feed-refresh.js
@@ -295,7 +295,10 @@ async function showPendingFeedVideos(onReady) {
         if (search) search.value = '';
         shortsOnly = false;
         subscriptionsChronological = true;
-        subscriptionSort = 'discovered_desc';
+        // Keep the order the user selected before opening the new-videos view.
+        // A newly detected older upload can therefore appear farther down when
+        // Subscriptions is ordered by upload date, instead of changing the
+        // entire inventory to detection time.
         if (typeof onReady === 'function') onReady();
         else showFeed();
         const visibleCount = visiblePendingFeedVideoCount(videoIds);

--- a/tests/unit/feed-refresh-regression.test.js
+++ b/tests/unit/feed-refresh-regression.test.js
@@ -117,9 +117,19 @@ test('Show verifies the discovered identities before clearing pending state', as
   expect(stored['ytvht.pendingFeedDiscovery.v1'].videoIds).toEqual([]);
   expect(context.newlyShownFeedVideoIds).toEqual(['video-1', 'video-2']);
   expect(context.subscriptionsChronological).toBe(true);
-  expect(context.subscriptionSort).toBe('discovered_desc');
+  expect(context.subscriptionSort).toBe('published_desc');
   expect(document.getElementById('search').value).toBe('');
   expect(context.showFeed).toHaveBeenCalledTimes(1);
+});
+
+test('Show preserves a previously selected Subscriptions order', async () => {
+  const { context } = runtime({ videoIds: ['video-1'] });
+  context.subscriptionSort = 'published_asc';
+
+  await context.showPendingFeedVideos();
+
+  expect(context.subscriptionsChronological).toBe(true);
+  expect(context.subscriptionSort).toBe('published_asc');
 });
 
 test('a failed Show preserves identities and exposes a working Retry action', async () => {


### PR DESCRIPTION
## Summary

Showing newly discovered subscription videos no longer changes the user-selected Subscriptions ordering to `discovered_desc`.

Previously, selecting **Show** after an upload scan always replaced the active order. That made an older upload detected during a later scan jump to the top and changed the entire inventory view.

The new behavior keeps the selected sort (for example, newest-upload-first or oldest-upload-first), while still opening the chronological Subscriptions view and showing the newly discovered IDs.

## Changes

- remove the unconditional `subscriptionSort = 'discovered_desc'` assignment;
- retain the current Subscriptions sort when opening the new-videos view;
- update the existing regression expectation; and
- add coverage for an explicitly selected ascending upload-date sort.

## Verification

- `npm test -- --runInBand tests/unit/feed-refresh-regression.test.js`
  - 9 tests passed.

## Scope

This affects only the presentation order after **Show**. Upload discovery, pending-state validation, retention recovery, and retry handling are unchanged.